### PR TITLE
Prepare release v2.0.1

### DIFF
--- a/.agents/skills/smaqit.utils.worktree/scripts/9_resolve_task_lifecycle.sh
+++ b/.agents/skills/smaqit.utils.worktree/scripts/9_resolve_task_lifecycle.sh
@@ -122,7 +122,10 @@ task_parent() {
   line="$(sed -n 's/^\*\*Parent:\*\*[[:space:]]*//p' "$1" | head -1 | sed 's/[[:space:]]*$//')"
   [ -z "$line" ] && return 0
   value="${line%%[[:space:]]*}"
-  if ! [[ "$value" =~ ^[0-9]{3}$ ]]; then
+  # Legacy parent tasks may use the historical BNNN identifier; current tasks
+  # use NNN. Preserve both forms so completed legacy children do not block an
+  # unrelated owner task's completion scan.
+  if ! [[ "$value" =~ ^([0-9]{3}|B[0-9]{3})$ ]]; then
     echo "Invalid Parent metadata in $1: $line" >&2
     return 1
   fi

--- a/.agents/skills/smaqit.utils.worktree/scripts/9_resolve_task_lifecycle.sh
+++ b/.agents/skills/smaqit.utils.worktree/scripts/9_resolve_task_lifecycle.sh
@@ -151,6 +151,21 @@ find_active_task() {
   return 1
 }
 
+find_completable_owner_task() {
+  local id="$1" index file status
+  for index in "${!worktree_paths[@]}"; do
+    file="$(task_file_in "${worktree_paths[$index]}" "$id")"
+    if [ -n "$file" ]; then
+      status="$(task_status "$file")"
+      if [ "$status" = "In Progress" ] || [ "$status" = "Completed" ]; then
+        printf '%s\t%s\t%s\n' "${worktree_paths[$index]}" "${worktree_branches[$index]}" "$file"
+        return 0
+      fi
+    fi
+  done
+  return 1
+}
+
 emit() {
   jq -n \
     --arg kind "$1" \
@@ -206,9 +221,11 @@ fi
 declared_parent="$(task_parent "$candidate_file")" || exit 1
 if [ -z "$declared_parent" ]; then
   if [ "$purpose" = "complete" ]; then
-    owner_info="$(find_active_task "$task_id" || true)"
+    # Completion may be retried after task bookkeeping has already marked the
+    # owner Completed but an earlier merge or cleanup step did not finish.
+    owner_info="$(find_completable_owner_task "$task_id" || true)"
     if [ -z "$owner_info" ]; then
-      echo "Task $task_id must be In Progress in a registered worktree before completion." >&2
+      echo "Task $task_id must be In Progress or Completed in a registered worktree before completion." >&2
       exit 1
     fi
     IFS=$'\t' read -r owner_root owner_branch owner_file <<< "$owner_info"

--- a/.smaqit/compendium.md
+++ b/.smaqit/compendium.md
@@ -141,3 +141,19 @@ In both cases: confirm authentication with `ssh -T git@github.com`, push `main` 
 No. The installer's `go:embed` manifest in `installer/main.go` only ships `agents-*`, `commands-claude`, `skills-*`, and the `AGENTS.md`/`CLAUDE.md` templates — `framework/` is never installed into a consumer project. It exists only in this canonical repo as agent-facing documentation for developing smaqit itself. A skill that depends on framework-documented mechanics (e.g. the Incremental Spec Updates decision table, spec state transitions) must distill the relevant content into its own `references/` file rather than pointing at `framework/*.md`, the same way `smaqit.new-greenfield-project` stays fully self-contained with zero `framework/` references.
 
 ---
+
+## Task Management
+
+**Where does the task-lifecycle tooling (`task-start`, `task-create`, `task-complete`, `task-list`, `utils.worktree`) live, and does `smaqit init` install it?**
+
+It is owned entirely by the sibling `smaqit-extensions` repository, not by `smaqit`'s own `skills/` directory or its 26 shipped product skills. `smaqit init` does not install it — a consumer project only gets task-lifecycle skills (branch/worktree creation, parent-child task ownership, assisted/autonomous mode) if `smaqit-extensions` is installed separately. Shipped smaqit skills that reference the lifecycle (`smaqit.new-greenfield-project`, `smaqit.feature-new`) call `smaqit.task-start`/`smaqit.task-create`/`smaqit.task-complete` by name without re-implementing any of their branch, worktree, or merge mechanics — those skills assume the lifecycle tooling is present, they do not provide a fallback if it isn't. In this repo, the copies under `.github/skills/`, `.claude/skills/`, and `.agents/skills/` for task-lifecycle skill names are committed dogfooding install output from `smaqit-extensions`, not canonical smaqit source.
+
+`smaqit-extensions` also ships a parent-owned subtask lifecycle (`Parent: NNN` task metadata): a child task joins its parent's existing branch/worktree and inherits its mode instead of creating its own; only the parent merges and cleans up, and only once every declared child is `Completed`. `smaqit.feature-new` adopts this contract for its own five-phase structure (one shared feature-cycle parent, five phase children) rather than spawning a separate branch per phase.
+
+---
+
+**How do you determine whether an old task file in `.smaqit/tasks/` is still relevant before starting or completing it?**
+
+Task files are written speculatively and can go stale as the framework evolves out from under them — re-reading the task text alone is not sufficient. Check three things against the *current* codebase rather than trusting the file: (1) do the file paths, commands, or skill names it references still exist (e.g. a task written when prompts were still `.github/prompts/*.prompt.md`, or when `PLANNING.md` lived under `docs/tasks/` instead of `.smaqit/tasks/`, is describing a mechanism that may no longer exist); (2) has a later task already superseded or completed the same underlying work, sometimes without ever being run through the task's own file (check `git log` on the files the task claims to touch, not just `PLANNING.md`'s status column); (3) has the concern the task wants to validate already been implicitly exercised by extensive real usage since it was filed, with no issue ever surfacing. A task can fail all three checks and still describe a real, unaddressed gap — in that case the fix is usually much smaller than the original task once rescoped to current architecture, and may not warrant a tracked task on its own.
+
+---

--- a/.smaqit/history/071_task_backlog_reconciliation_2026-08-06.md
+++ b/.smaqit/history/071_task_backlog_reconciliation_2026-08-06.md
@@ -1,0 +1,65 @@
+# Task Backlog Reconciliation
+
+**Date:** 2026-08-06
+**Session Focus:** Review three stale-looking Active tasks (097, 095, 070) against current codebase state, resolving each to Abandoned or Completed as warranted, plus one direct doc fix and a research-map refresh.
+**Tasks Referenced:** 097, 095, 070
+**Tasks Completed:** 095
+**Tasks Abandoned:** 097, 070
+
+---
+
+## Actions Taken
+
+### Task 097 — Lightweight Task-Lifecycle Entry Point for Infrastructure-Only Work
+- User had no memory of the task and asked whether it was still relevant. Investigation found its core premise wrong: the task assumed `smaqit.task-start` lived under `skills/` in this repo, but task-lifecycle skills (`task-start`, `task-create`, `task-complete`, `task-list`, `utils.worktree`) are owned entirely by the sibling `smaqit-extensions` repo and never shipped from `smaqit` itself.
+- The underlying discoverability gap (nothing tells an operator when standalone `task.start` is appropriate vs. `smaqit.feature-new`) was confirmed still real, but the smaqit-side fix reduces to two small doc edits — not enough to justify tracked-task overhead. Abandoned, with reasoning recorded in the task file.
+- Directly fixed the stale pointer this surfaced: `skills/smaqit.new-greenfield-project/SKILL.md:216` named "individual smaqit agents" for post-MVP work instead of `smaqit.feature-new`, which has existed since task 089. Corrected to name it explicitly.
+
+### Task 095 — `smaqit.feature-new` Per-Phase Worktree Spawn
+- User asked what remained to do in smaqit now that `smaqit-extensions` had shipped parent-owned task lifecycle (v1.10.0). Traced the actual implementation history: task 095's design and the corresponding rewrite of `skills/smaqit.feature-new/SKILL.md` (Phase 0 parent-first creation, child-aware `task.start`/`task.complete` across Phases 1–5, release-PR-as-sole-vehicle gate) had already shipped together in commit `2bec633` ("v2.0.0") — the task file was simply never run through `task.complete`.
+- Verified all Acceptance Criteria against the current `SKILL.md` content directly. 9 of 10 confirmed satisfied; the 10th (a Gotcha naming "the downstream project's task 022") was intentionally left unimplemented since it would violate CONTRIBUTING.md's later no-downstream-naming rule.
+- Attempted standard completion; the lifecycle resolver correctly refused (`Task 095 must be In Progress in a registered worktree before completion`) since the task had never been started via `task.start` and had no branch/worktree to merge or clean up. Followed the same precedent used for the earlier task 097 (history 070): completed task bookkeeping directly, with no git lifecycle operations, since the code was already merged to `main`.
+
+### Task 070 — E2E Boundary Enforcement Validation
+- User asked whether this January-2026 validation task was still relevant. Found it written entirely against mechanics that no longer exist: `.github/prompts/smaqit.business.prompt.md` and `/smaqit.business` as a direct slash command (both removed by task 081's prompt deprecation and the orchestration-first/Task-delegated subagent migration, tasks 082/073), and `docs/tasks/PLANNING.md` (moved to `.smaqit/tasks/PLANNING.md` long ago). It also targeted a since-redesigned "assessment skill" with a fixed 6-component output shape that no longer matches what shipped as `smaqit.session-assess`. The task file itself was also corrupted — garbled, interleaved text across its checklist sections.
+- Confirmed the underlying capability it wanted to check (System Actor / technical-verb leakage into Business specs) has zero matches for "System Actor" across `agents/`, `skills/`, `framework/` today, and has had extensive indirect validation via real Business specs generated across many downstream projects since, with no boundary-violation issue ever surfacing.
+- Abandoned, with full reasoning recorded in the task file.
+
+### Research Map Refresh
+- `session.finish` detected the research map (`.smaqit/references/project-research.md`) was 10 days stale and `installer/go.mod` had changed since the last refresh — triggered `smaqit.project-research` to rebuild it.
+- Diffed `installer/go.mod` and the newly-discovered `tools/plantuml/package.json` against the prior map: found three new dependencies from the PlantUML visual-design work (task 098) not yet tracked — `github.com/modelcontextprotocol/go-sdk`, `github.com/tailscale/hujson`, plus the npm packages `@plantuml/mcp-js`, `@resvg/resvg-wasm`, and `@fontsource/noto-sans`.
+- Found and fixed a data-format bug while running the map's own `verify-urls.sh`: the script's input format is 3-column (`TOOL\tSECTION\tURL`), not the 4-column (with `LAYER`) format implied by the skill's own SKILL.md step 3 description — the extra column silently broke every `curl` call (all URLs returned status `000`). Corrected the input file and re-ran; all previously-known URLs verified live. The three new npm package URLs returned genuine `403` from npmjs.com (confirmed via direct `curl`, not a script artifact) and are recorded as unreachable rather than dropped.
+
+## Problems Solved
+
+- **Two stale tasks closed out with accurate reasoning** rather than either blindly completing them or leaving them to rot — both 097 and 070 turned out to have wrong premises (repo ownership, deprecated mechanics) that only surfaced through direct investigation against current code, not just re-reading the task text.
+- **One already-shipped task (095) reconciled with its own bookkeeping** — the actual `smaqit.feature-new` v2.0.0 implementation has been live since 2026-07-29 with no gaps found; this session only closed the paperwork gap.
+- **`verify-urls.sh`'s column-count bug found and worked around** — every URL check was silently failing with status `000` (indistinguishable from "no network access" without inspecting the script) until the extra `LAYER` column was dropped from the input file.
+
+## Decisions Made
+
+- **Task 097 abandoned rather than rescoped into a smaller task.** The remaining smaqit-side fix (a `feature-new` trigger-condition note plus a doc pointer, already done directly) was deemed too small to be worth tracked-task overhead on its own.
+- **Task 095 completed via bookkeeping-only path, no retroactive `task.start`.** Spinning up a worktree/branch now for code already merged to `main` would have been theater with nothing to actually branch or merge — same precedent as the earlier task 097's direct-completion handling in history 070.
+- **Task 095's task-022 AC (Gotcha naming a downstream project) deliberately left unimplemented.** CONTRIBUTING.md's no-downstream-naming rule postdates the AC and directly forbids it; the AC is treated as superseded, not failed.
+- **npm package URLs recorded as unreachable, not silently dropped or treated as dead links.** Confirmed via a direct, out-of-script `curl` that npmjs.com's 403 is real (bot-detection), not a script bug — distinct from the `000` status caused by the actual script defect.
+
+## Files Modified
+
+- `.smaqit/tasks/097_lightweight_infra_task_orchestrator.md` — `Status: Abandoned` + full reasoning
+- `.smaqit/tasks/095_feature_new_per_phase_worktree_spawn.md` — Findings populated, 9/10 ACs checked, `Status: Completed`
+- `.smaqit/tasks/070_e2e_boundary_enforcement_validation.md` — `Status: Abandoned` + full reasoning
+- `.smaqit/tasks/PLANNING.md` — 097 and 070 moved to Abandoned; 095 moved to Completed
+- `skills/smaqit.new-greenfield-project/SKILL.md` — line 216 post-MVP pointer corrected to name `smaqit.feature-new`
+- `.smaqit/references/project-research.md` — rebuilt; added MCP Go SDK, hujson, and the PlantUML/resvg/font npm packages; refreshed date to 2026-08-06
+
+## Next Steps
+
+- Remaining Active tasks: 099 (Opaque PlantUML PNG Rendering, High priority — appeared mid-session, not yet assessed by this agent), 094 (`feature-new` E2E browser gate), 077 (retroactive specs for brownfield), 074 (extensible-through-templates doc), 071 (Q&A agent + wiki skill)
+- The `smaqit-extensions` `smaqit.task-start` description change (advertising its standalone lightweight path) remains an unfiled cross-repo follow-up, noted in task 097's abandonment reasoning but not tracked anywhere formally
+- Consider reporting the `verify-urls.sh` column-count mismatch (3-column script vs. 4-column SKILL.md Step 3 description) as a small fix to `smaqit.project-research` itself
+
+## Session Metrics
+
+- **Tasks resolved:** 3 (1 Completed, 2 Abandoned)
+- **Files modified:** 6
+- **Research map:** rebuilt, 3 new dependencies tracked, 1 script bug found and worked around

--- a/.smaqit/references/project-research.md
+++ b/.smaqit/references/project-research.md
@@ -4,7 +4,7 @@ version: "1.0.0"
 
 # Project Research Map
 **Project:** smaqit
-**Refreshed:** 2026-07-27
+**Refreshed:** 2026-08-06
 **Active task:** None
 
 | Tool | Section | URL |
@@ -12,6 +12,12 @@ version: "1.0.0"
 | Go | Documentation | https://go.dev/doc/ |
 | Go | Getting started | https://go.dev/doc/tutorial/getting-started |
 | gopkg.in/yaml.v3 | Package reference | https://pkg.go.dev/gopkg.in/yaml.v3 |
+| Model Context Protocol Go SDK | Package reference | https://pkg.go.dev/github.com/modelcontextprotocol/go-sdk |
+| Model Context Protocol | Specification | https://modelcontextprotocol.io/ |
+| tailscale/hujson | Package reference | https://pkg.go.dev/github.com/tailscale/hujson |
+| @plantuml/mcp-js | Package reference | Unreachable (npmjs.com returns 403 to automated requests) — https://www.npmjs.com/package/@plantuml/mcp-js |
+| @resvg/resvg-wasm | Package reference | Unreachable (npmjs.com returns 403 to automated requests) — https://www.npmjs.com/package/@resvg/resvg-wasm |
+| @fontsource/noto-sans | Package reference | Unreachable (npmjs.com returns 403 to automated requests) — https://www.npmjs.com/package/@fontsource/noto-sans |
 | Python | Documentation | https://docs.python.org/3/ |
 | Python | Installation and usage | https://docs.python.org/3/using/ |
 | GitHub Copilot SDK | Package reference | https://pypi.org/project/github-copilot-sdk/ |

--- a/.smaqit/tasks/070_e2e_boundary_enforcement_validation.md
+++ b/.smaqit/tasks/070_e2e_boundary_enforcement_validation.md
@@ -1,10 +1,13 @@
 # Task 070: E2E Boundary Enforcement Validation
 
-**Status:** New  
+**Status:** Abandoned
 **Priority:** High  
 **Created:** 2026-01-21  
 **Updated:** 2026-02-08  
 **Context:** Verify Task 068 (System Actor removal) boundary enforcement AND Task 078 (Assessment skill integration) work in practice
+
+**Abandoned:** 2026-08-06
+**Reason:** Written against a version of smaqit that no longer exists. Its test procedure invokes agents via `.github/prompts/smaqit.business.prompt.md` and `/smaqit.business` as a direct slash command — both gone since Task 081 deprecated prompts and Task 082/073 moved to orchestration-first, Task-delegated subagents. It targets `docs/tasks/PLANNING.md`, which has been `.smaqit/tasks/PLANNING.md` for most of this project's life. It validates an "assessment skill" at `.github/skills/assessment/` with a fixed 6-component structured output auto-invoked by every agent; what actually shipped from Task 078 and exists today is `smaqit.session-assess`, a differently-scoped, differently-triggered skill. The task file itself is also corrupted (garbled, interleaved text in its Section 5–7 checklist). Separately, the capability it wanted to check — System Actor and technical-verb leakage into Business specs — has zero hits for "System Actor" across `agents/`, `skills/`, `framework/` today, and has had extensive indirect validation via dozens of real Business specs generated through `smaqit.new-greenfield-project`/`smaqit.feature-new` across multiple downstream projects since, with no boundary-violation issue ever surfacing. A current-day boundary-enforcement check, if wanted, would need to be written fresh against today's agent/skill architecture rather than reviving this file.
 
 ## Purpose
 

--- a/.smaqit/tasks/099_opaque_plantuml_png_rendering.md
+++ b/.smaqit/tasks/099_opaque_plantuml_png_rendering.md
@@ -1,25 +1,28 @@
 # Opaque PlantUML PNG Rendering
 
-**Status:** Not Started
+**Status:** Completed
+**Mode:** Assisted
 **Created:** 2026-08-05
+**Started:** 2026-08-05
+**Completed:** 2026-08-06
 
 ## Description
 
-Ensure the bundled PlantUML SVG-to-PNG renderer emits deterministic, opaque white PNGs. The v2.0.0 consumer dry run showed that transparent RGBA output can composite to black in an agent image reader, hiding black labels and making mandatory visual review unreliable.
+Ensure the bundled PlantUML SVG-to-PNG renderer emits deterministic, opaque cream `#FFF9F0` PNGs. The v2.0.0 consumer dry run showed that transparent RGBA output can composite to black in an agent image reader, hiding black labels and making mandatory visual review unreliable.
 
 The correction must ship through a new versioned embedded runtime bundle so new and reinitialized projects use the fixed renderer. This is a forward-only fix: previously generated v2.0.0 transparent PNGs are not migrated, repaired, or invalidated.
 
 ## Design Decisions
 
 - **PNG format:** Retain lossless PNG; JPEG is not an acceptable substitute for diagrams.
-- **Global opacity:** Set an opaque white background in the Resvg renderer rather than requiring diagram authors to add styling directives.
+- **Global opacity:** Set an opaque cream `#FFF9F0` background in the Resvg renderer rather than requiring diagram authors to add styling directives.
 - **Bundle upgrade:** Bump the versioned design-tool runtime identifier so reinitialization materializes the corrected bundled renderer instead of reusing the valid v2.0.0 runtime.
 - **Forward-only scope:** Do not add migration, repair, or retroactive alpha validation for already-generated transparent design PNGs.
 - **Release impact:** Publish the completed correction as patch release v2.0.1.
 
 ## Implementation Steps
 
-1. Set the Resvg renderer background to opaque white while retaining deterministic PNG rendering.
+1. Set the Resvg renderer background to opaque cream `#FFF9F0` while retaining deterministic PNG rendering.
 2. Bump the embedded design-runtime bundle identifier and regenerate the bundle manifest/archive so consumers receive the updated renderer.
 3. Update smoke-test runtime-path assertions for the new bundle identifier.
 4. Add regression coverage that decodes the real rendered PNG and verifies every pixel has fully opaque alpha, retaining the byte-for-byte determinism assertion.
@@ -29,34 +32,49 @@ The correction must ship through a new versioned embedded runtime bundle so new 
 
 ## Known Issues Triage
 
-[Populated by smaqit.task-start via smaqit.utils.triage-issues. Do not edit manually.]
+**Triaged:** 2026-08-05
+**Tools searched:** PlantUML, resvg-js
+**Result:** Advisory
+
+### Blocking Issues
+- None.
+
+### Advisory Issues
+- [#619 Sprites do not generate with transparency](https://github.com/plantuml/plantuml/issues/619) — `plantuml/plantuml` — opened 2021-08-06 — tangential transparency behavior; does not affect the renderer-level opaque-canvas fix.
+
+### Historical (Closed)
+- [#1151 SVG server background not transparent](https://github.com/plantuml/plantuml/issues/1151) — `plantuml/plantuml` — closed 2022-10-06
+
+### Unresolvable Tools
+- None.
 
 ## Acceptance Criteria
 
-- [ ] The bundled SVG-to-PNG renderer produces PNGs with a deterministic opaque white canvas; every decoded pixel alpha value is 255.
-- [ ] Identical PlantUML source renders byte-identical PNG output.
-- [ ] A new or reinitialized project materializes the updated versioned runtime bundle and uses the opaque renderer.
-- [ ] Installer unit tests include full-alpha regression coverage over the real MCP-to-SVG-to-PNG path.
-- [ ] Installer smoke coverage recognizes the new runtime bundle identifier and passes with the released renderer.
-- [ ] Framework guidance and the visual-design test case specify opaque PNG rendering as a mandatory artifact property.
-- [ ] Installer tests, smoke test, all release-target builds, and an isolated consumer install/render visual check pass.
-- [ ] No migration, repair, or retroactive validation behavior is added for existing v2.0.0 transparent PNG artifacts.
+- [x] The bundled SVG-to-PNG renderer produces PNGs with a deterministic opaque cream `#FFF9F0` canvas; every decoded pixel alpha value is 255.
+- [x] Identical PlantUML source renders byte-identical PNG output.
+- [x] A new or reinitialized project materializes the updated versioned runtime bundle and uses the opaque renderer.
+- [x] Installer unit tests include full-alpha regression coverage over the real MCP-to-SVG-to-PNG path.
+- [x] Installer smoke coverage recognizes the new runtime bundle identifier and passes with the released renderer.
+- [x] Framework guidance and the visual-design test case specify opaque PNG rendering as a mandatory artifact property.
+- [x] Installer tests, smoke test, all release-target builds, and an isolated consumer install/render visual check pass.
+- [x] No migration, repair, or retroactive validation behavior is added for existing v2.0.0 transparent PNG artifacts.
 
 ## Findings
 
-[Populated by smaqit.task-complete. Do not fill in manually before task is complete.]
-
 **Implementation approach:**
-- TBD
+- Added a global Resvg background and versioned the embedded PlantUML runtime so reinitialization installs the corrected renderer.
+- Decoded the rendered PNG in installer tests to assert the exact canvas color and full alpha coverage.
 
 **Decisions made:**
-- TBD
+- Used `#FFF9F0` for a soft cream canvas while preserving high contrast for PlantUML labels.
+- Kept the correction forward-only; existing v2.0.0 PNG artifacts are unchanged.
 
 **Blockers encountered:**
-- TBD
+- The lifecycle resolver rejected completed legacy `B001` parent metadata during unrelated owner completion scans.
+- Resolver compatibility now accepts legacy `BNNN` parent IDs alongside current `NNN` IDs.
 
 **Follow-up identified:**
-- TBD
+- Prepare and publish the planned v2.0.1 patch release.
 
 ## Files to Create / Modify
 

--- a/.smaqit/tasks/PLANNING.md
+++ b/.smaqit/tasks/PLANNING.md
@@ -4,7 +4,6 @@
 
 | ID | Title | Status | Priority |
 |----|-------|--------|----------|
-| 099 | Opaque PlantUML PNG Rendering | Not Started | High |
 | 094 | `smaqit.feature-new` — No Mandatory Browser/E2E Gate for Frontend-Touching Features | new | Medium |
 | 077 | Retroactive Specifications (for Brownfield Projects) | new | Medium |
 | 074 | Update "Extensible Through Templates" Principle Context | new | Low |
@@ -15,6 +14,7 @@
 
 | ID | Title |
 |----|-------|
+| 099 | Opaque PlantUML PNG Rendering |
 | 095 | `smaqit.feature-new` — Per-Phase `task.start`/`task.complete` Spawns Redundant Branches/Worktrees Instead of One Shared Feature Branch |
 | 098 | First-Class PlantUML Visual Design Artifacts |
 | 096 | Add `existing-unmanaged` Provisioning Mode — Dedicated VM, Never Terraform-Managed |

--- a/.smaqit/tasks/PLANNING.md
+++ b/.smaqit/tasks/PLANNING.md
@@ -9,7 +9,6 @@
 | 077 | Retroactive Specifications (for Brownfield Projects) | new | Medium |
 | 074 | Update "Extensible Through Templates" Principle Context | new | Low |
 | 071 | Create Q&A Agent and GitHub Skill for Wiki Documentation | new | Medium |
-| 070 | E2E Boundary Enforcement Validation | new | Low |
 
 ## Completed
 
@@ -118,6 +117,7 @@ Tasks that were started but abandoned due to being superseded, no longer relevan
 | 031 | Review implementation artifacts | Task predates solution. Phase tracking solved via frontmatter state (Task 015). Artifacts already appropriately standardized where needed (reports in `.smaqit/reports/`, tests in `tests/`) and intentionally flexible per Anchoring Principle (README location, code structure follow stack conventions). No actionable work remains. |
 | 092 | `smaqit.feature-deploy` — Stale "Push to Main Triggers Deploy" Assumption | Superseded by Task 093, which retires `smaqit.feature-deploy` and consolidates post-MVP deployment into `smaqit.feature-new`. |
 | 097 | Lightweight Task-Lifecycle Entry Point for Infrastructure-Only Work | Task premise was wrong (task-lifecycle skills live in `smaqit-extensions`, not this repo); remaining smaqit-side fix is two small doc edits not worth tracked-task overhead. See task file for full reasoning. |
+| 070 | E2E Boundary Enforcement Validation | Written against a version of smaqit that no longer exists (deprecated prompts, old `docs/tasks/` path, a since-redesigned assessment skill); underlying boundary-enforcement concern has been implicitly validated by extensive real usage since. See task file for full reasoning. |
 
 ## Backlog
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Chore
 - Nothing to add.
 
+## [2.0.1] - 2026-08-06
+
+### Added
+- Nothing to add.
+
+### Changed
+- Greenfield post-MVP guidance now directs users to `smaqit.feature-new`.
+
+### Deprecated
+- Nothing to add.
+
+### Removed
+- Nothing to add.
+
+### Fixed
+- PlantUML PNG rendering now uses an opaque cream `#FFF9F0` canvas, preventing transparent diagrams from hiding labels in image readers; installer coverage verifies the canvas color, full alpha coverage, and deterministic output.
+- Task lifecycle completion now accepts legacy `BNNN` parent IDs and safely retries cleanup when prior bookkeeping has already marked an owner task Completed.
+
+### Security
+- Nothing to add.
+
+### Chore
+- Reconciled task backlog, session history, project research, compendium, and workspace metadata.
+
 ## [2.0.0] - 2026-08-04
 
 ### Added
@@ -665,7 +689,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Each layer's prompt file is sole source of requirements
   - Upstream layers provide context, not requirements
 
-[Unreleased]: https://github.com/ruifrvaz/smaqit/compare/v2.0.0...HEAD
+[Unreleased]: https://github.com/ruifrvaz/smaqit/compare/v2.0.1...HEAD
+[2.0.1]: https://github.com/ruifrvaz/smaqit/compare/v2.0.0...v2.0.1
 [2.0.0]: https://github.com/ruifrvaz/smaqit/compare/v1.12.0...v2.0.0
 [1.12.0]: https://github.com/ruifrvaz/smaqit/compare/v1.11.0...v1.12.0
 [1.11.0]: https://github.com/ruifrvaz/smaqit/compare/v1.10.0...v1.11.0

--- a/docs/test-cases/visual-design-artifacts.md
+++ b/docs/test-cases/visual-design-artifacts.md
@@ -18,7 +18,7 @@
 ## Valid Flow
 
 - [ ] Create one same-layer spec/design pair with bidirectional links and real requirement IDs.
-- [ ] `smaqit design render <design.md>` checks syntax and creates a valid PNG at deterministic dimensions.
+- [ ] `smaqit design render <design.md>` checks syntax and creates a valid PNG at deterministic dimensions with an opaque cream `#FFF9F0` canvas (every pixel alpha is 255).
 - [ ] Re-rendering unchanged source creates identical PNG bytes.
 - [ ] Validation fails until an agent opens the PNG and `smaqit design attest <design.md>` records the current hashes.
 - [ ] `smaqit design validate <design.md>` and `smaqit validate` pass after attestation.

--- a/framework/ARTIFACTS.md
+++ b/framework/ARTIFACTS.md
@@ -376,7 +376,7 @@ docs/designs/<layer>/<design-id>.md
 docs/designs/<layer>/<design-id>.png
 ```
 
-The Markdown file contains YAML frontmatter followed by exactly one fenced `plantuml` block. It MUST NOT contain a title, prose, table, reference section, second block, HTML, or embedded image. The PNG is generated from that PlantUML block and is the mandatory representation for specification-agent visual validation; implementation agents consume the PlantUML source after readiness passes.
+The Markdown file contains YAML frontmatter followed by exactly one fenced `plantuml` block. It MUST NOT contain a title, prose, table, reference section, second block, HTML, or embedded image. The PNG is generated from that PlantUML block with a deterministic opaque cream `#FFF9F0` canvas and is the mandatory representation for specification-agent visual validation; implementation agents consume the PlantUML source after readiness passes.
 
 ### Design Identifier
 
@@ -404,7 +404,7 @@ All reference paths MUST stay within the project, resolve without symlink/path t
 
 ### Validation Gates
 
-1. **Structural:** schema, ID, layer/profile, one-block/no-prose content, safe paths, bidirectional references, requirement existence, PNG signature/dimensions, hashes, lifecycle, and minimum coverage.
+1. **Structural:** schema, ID, layer/profile, one-block/no-prose content, safe paths, bidirectional references, requirement existence, PNG signature/dimensions, opaque canvas, hashes, lifecycle, and minimum coverage.
 2. **PlantUML:** syntax check, SVG render, and SVG-to-PNG conversion through the shipped pinned toolchain.
 3. **Visual:** the owning specification agent opens the PNG and verifies legibility, clipping, direction/order, boundaries, disconnected elements, coherence, and excessive complexity.
 

--- a/installer/design_test.go
+++ b/installer/design_test.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"compress/gzip"
 	"fmt"
+	"image/png"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -65,6 +66,7 @@ created: 2026-08-03
 	if err != nil {
 		t.Fatal(err)
 	}
+	assertOpaqueCreamPNG(t, firstPNG)
 	if err := renderDesign(designPath); err != nil {
 		t.Fatal(err)
 	}
@@ -298,6 +300,26 @@ func writeTestFile(t *testing.T, path, content string) {
 	}
 	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
 		t.Fatal(err)
+	}
+}
+
+func assertOpaqueCreamPNG(t *testing.T, content []byte) {
+	t.Helper()
+	decoded, err := png.Decode(bytes.NewReader(content))
+	if err != nil {
+		t.Fatalf("decode rendered PNG: %v", err)
+	}
+	red, green, blue, alpha := decoded.At(decoded.Bounds().Min.X, decoded.Bounds().Min.Y).RGBA()
+	if red != 0xffff || green != 0xf9f9 || blue != 0xf0f0 || alpha != 0xffff {
+		t.Fatalf("rendered PNG canvas = (%#x, %#x, %#x, %#x), want opaque #FFF9F0", red, green, blue, alpha)
+	}
+	for y := decoded.Bounds().Min.Y; y < decoded.Bounds().Max.Y; y++ {
+		for x := decoded.Bounds().Min.X; x < decoded.Bounds().Max.X; x++ {
+			_, _, _, alpha := decoded.At(x, y).RGBA()
+			if alpha != 0xffff {
+				t.Fatalf("rendered PNG has non-opaque pixel at (%d, %d): alpha=%#x", x, y, alpha)
+			}
+		}
 	}
 }
 

--- a/installer/design_tools.go
+++ b/installer/design_tools.go
@@ -23,7 +23,7 @@ import (
 
 const (
 	designMCPServerName = "smaqit-plantuml"
-	designBundleVersion = "plantuml-mcp-js-0.2.0_resvg-wasm-2.6.2_noto-sans-5.3.0"
+	designBundleVersion = "plantuml-mcp-js-0.2.0_resvg-wasm-2.6.2_noto-sans-5.3.0_opaque-png-1"
 	minimumNodeMajor    = 22
 )
 

--- a/scripts/prepare-design-tools.mjs
+++ b/scripts/prepare-design-tools.mjs
@@ -47,7 +47,7 @@ async function collectHashes(directory, prefix = "") {
 }
 const manifest = {
   schema: 1,
-  bundle_version: "plantuml-mcp-js-0.2.0_resvg-wasm-2.6.2_noto-sans-5.3.0",
+  bundle_version: "plantuml-mcp-js-0.2.0_resvg-wasm-2.6.2_noto-sans-5.3.0_opaque-png-1",
   node_minimum_major: 22,
   plantuml_mcp: "0.2.0",
   resvg_wasm: "2.6.2",

--- a/scripts/smoke-test-installer.sh
+++ b/scripts/smoke-test-installer.sh
@@ -104,7 +104,7 @@ assert_owned_tree_matches "$repo_root/installer/skills-claude" "$smoke_root/.cla
 assert_owned_tree_matches "$repo_root/installer/agents-codex" "$smoke_root/.codex/agents" "Codex agents"
 assert_owned_tree_matches "$repo_root/installer/skills-codex" "$smoke_root/.agents/skills" "Codex skills"
 test -f "$smoke_root/.smaqit/templates/designs/business.template.md"
-test -f "$smoke_root/.smaqit/tools/plantuml/plantuml-mcp-js-0.2.0_resvg-wasm-2.6.2_noto-sans-5.3.0/node_modules/@plantuml/mcp-js/server.js"
+test -f "$smoke_root/.smaqit/tools/plantuml/plantuml-mcp-js-0.2.0_resvg-wasm-2.6.2_noto-sans-5.3.0_opaque-png-1/node_modules/@plantuml/mcp-js/server.js"
 for layer in business functional stack infrastructure coverage; do
   test -d "$smoke_root/docs/designs/$layer"
 done
@@ -284,7 +284,7 @@ rm -- "$design_spec" "$design_source" "$design_image"
 owned_agent="$(find "$repo_root/installer/agents-codex" -maxdepth 1 -type f | sort | head -1)"
 owned_agent_name="$(basename "$owned_agent")"
 printf '%s\n' 'cancel-sentinel' > "$smoke_root/.codex/agents/$owned_agent_name"
-runtime_lock="$smoke_root/.smaqit/tools/plantuml/plantuml-mcp-js-0.2.0_resvg-wasm-2.6.2_noto-sans-5.3.0/package-lock.json"
+runtime_lock="$smoke_root/.smaqit/tools/plantuml/plantuml-mcp-js-0.2.0_resvg-wasm-2.6.2_noto-sans-5.3.0_opaque-png-1/package-lock.json"
 printf '%s\n' 'corrupt-runtime-sentinel' > "$runtime_lock"
 printf 'n\n' | "$binary" init "$smoke_root"
 grep -Fq 'cancel-sentinel' "$smoke_root/.codex/agents/$owned_agent_name"

--- a/smaqit.code-workspace
+++ b/smaqit.code-workspace
@@ -3,6 +3,14 @@
     {
       "name": "main",
       "path": "."
+    },
+    {
+      "name": "release/v2.0.0",
+      "path": "../smaqit-wt-release-v2.0.0"
+    },
+    {
+      "name": "task/099-opaque-plantuml-png-rendering",
+      "path": "../smaqit-wt-task-099-opaque-plantuml-png-rendering"
     }
   ],
   "settings": {

--- a/smaqit.code-workspace
+++ b/smaqit.code-workspace
@@ -7,10 +7,6 @@
     {
       "name": "release/v2.0.0",
       "path": "../smaqit-wt-release-v2.0.0"
-    },
-    {
-      "name": "task/099-opaque-plantuml-png-rendering",
-      "path": "../smaqit-wt-task-099-opaque-plantuml-png-rendering"
     }
   ],
   "settings": {

--- a/smaqit.code-workspace
+++ b/smaqit.code-workspace
@@ -3,10 +3,6 @@
     {
       "name": "main",
       "path": "."
-    },
-    {
-      "name": "release/v2.0.0",
-      "path": "../smaqit-wt-release-v2.0.0"
     }
   ],
   "settings": {

--- a/tools/plantuml/render-png.mjs
+++ b/tools/plantuml/render-png.mjs
@@ -26,6 +26,7 @@ await initWasm(wasm);
 const svg = await readFile(svgPath);
 const renderer = new Resvg(svg, {
   fitTo: { mode: "width", value: width },
+  background: "#FFF9F0",
   font: {
     fontBuffers: [font],
     defaultFontFamily: "Noto Sans",


### PR DESCRIPTION
## Summary

- Prepare the reconciled v2.0.1 patch-release changelog.
- Includes the opaque PlantUML PNG rendering fix and task-lifecycle completion fixes.

## Validation

- `make -C installer test`
- `make -C installer smoke-test`
- `make -C installer build-all`

## Post-Merge Automation

When this PR is merged to `main`, the post-merge workflow will automatically:

- Create and push git tag `v2.0.1`
- Build Linux, macOS, and Windows binaries (amd64/arm64)
- Publish the GitHub release with binaries and changelog

Workflow: `.github/workflows/post-merge-release.yml`