### PR TITLE
Prepare release v2.0.2

### DIFF
--- a/.smaqit/tasks/100_ignore_managed_plantuml_runtime_files.md
+++ b/.smaqit/tasks/100_ignore_managed_plantuml_runtime_files.md
@@ -1,7 +1,10 @@
 # Ignore Managed PlantUML Runtime Files
 
-**Status:** Not Started
+**Status:** Completed
+**Mode:** Assisted
 **Created:** 2026-08-06
+**Started:** 2026-08-06
+**Completed:** 2026-08-06
 
 ## Description
 
@@ -25,32 +28,47 @@ The forward fix must add and preserve a narrow Git ignore rule for the managed t
 
 ## Known Issues Triage
 
-[Populated by smaqit.task-start via smaqit.utils.triage-issues. Do not edit manually.]
+**Triaged:** 2026-08-06
+**Tools searched:** PlantUML
+**Result:** Clear
+
+### Blocking Issues
+- None.
+
+### Advisory Issues
+- None.
+
+### Historical (Closed)
+- None relevant to managed Git-ignore behavior.
+
+### Unresolvable Tools
+- None.
 
 ## Acceptance Criteria
 
-- [ ] A fresh `smaqit init` results in `.smaqit/tools/` being ignored by Git.
-- [ ] `smaqit update` adds the managed ignore rule to an existing project without overwriting unrelated `.gitignore` content.
-- [ ] Repeated initialization or update does not duplicate the ignore rule.
-- [ ] The ignore rule does not exclude `docs/designs/**/*.md` or `docs/designs/**/*.png`.
-- [ ] Installer unit and smoke tests cover the managed runtime ignore behavior.
-- [ ] Existing projects with already-tracked runtime files are not modified or untracked automatically.
+- [x] A fresh `smaqit init` results in `.smaqit/tools/` being ignored by Git.
+- [x] `smaqit update` adds the managed ignore rule to an existing project without overwriting unrelated `.gitignore` content.
+- [x] Repeated initialization or update does not duplicate the ignore rule.
+- [x] The ignore rule does not exclude `docs/designs/**/*.md` or `docs/designs/**/*.png`.
+- [x] Installer unit and smoke tests cover the managed runtime ignore behavior.
+- [x] Existing projects with already-tracked runtime files are not modified or untracked automatically.
 
 ## Findings
 
-[Populated by smaqit.task-complete. Do not fill in manually before task is complete.]
-
 **Implementation approach:**
-- TBD
+- Added an idempotent installer helper that appends only `.smaqit/tools/` after successful runtime materialization.
+- Covered helper behavior in Go tests and consumer Git behavior in the installer smoke test.
 
 **Decisions made:**
-- TBD
+- Preserve existing ignore-file content and its LF or CRLF convention.
+- Leave already-tracked runtime files unchanged; the rule affects only future untracked files.
 
 **Blockers encountered:**
-- TBD
+- The initial task registration had to be committed before creating an isolated worktree so the branch inherited its task file.
+- No upstream PlantUML issue affected this installer-owned change.
 
 **Follow-up identified:**
-- TBD
+- Include the forward fix in the next patch release.
 
 ## Files to Create / Modify
 

--- a/.smaqit/tasks/100_ignore_managed_plantuml_runtime_files.md
+++ b/.smaqit/tasks/100_ignore_managed_plantuml_runtime_files.md
@@ -1,0 +1,66 @@
+# Ignore Managed PlantUML Runtime Files
+
+**Status:** Not Started
+**Created:** 2026-08-06
+
+## Description
+
+Ensure `smaqit init` and `smaqit update` prevent the embedded PlantUML runtime under `.smaqit/tools/` from appearing as thousands of untracked project files. The runtime is a generated, versioned installation artifact containing pinned MCP, Resvg/WASM, font, and Node dependencies; it must remain local to each consumer project and never be committed.
+
+The forward fix must add and preserve a narrow Git ignore rule for the managed tools directory without ignoring canonical design artifacts. `docs/designs/**/*.md` and `docs/designs/**/*.png` remain project-owned and versioned.
+
+## Design Decisions
+
+- **Ignore boundary:** Add `.smaqit/tools/` to the consumer project's root `.gitignore`; do not ignore `.smaqit/` broadly.
+- **Preservation:** Merge the managed rule idempotently into an existing `.gitignore` without overwriting unrelated user rules.
+- **Forward-only:** Do not delete, migrate, or automatically untrack runtime files already added to consumer Git indexes.
+
+## Implementation Steps
+
+1. Locate the initialization/update path that materializes the bundled design runtime.
+2. Add an idempotent managed `.gitignore` update for `.smaqit/tools/`, preserving existing file content and line endings as appropriate.
+3. Cover fresh initialization, reinitialization with an existing `.gitignore`, and update behavior in installer tests and smoke coverage.
+4. Confirm Git ignores the runtime while still tracking canonical `docs/designs/` Markdown and PNG artifacts.
+5. Document the managed-runtime ignore behavior for consumers.
+
+## Known Issues Triage
+
+[Populated by smaqit.task-start via smaqit.utils.triage-issues. Do not edit manually.]
+
+## Acceptance Criteria
+
+- [ ] A fresh `smaqit init` results in `.smaqit/tools/` being ignored by Git.
+- [ ] `smaqit update` adds the managed ignore rule to an existing project without overwriting unrelated `.gitignore` content.
+- [ ] Repeated initialization or update does not duplicate the ignore rule.
+- [ ] The ignore rule does not exclude `docs/designs/**/*.md` or `docs/designs/**/*.png`.
+- [ ] Installer unit and smoke tests cover the managed runtime ignore behavior.
+- [ ] Existing projects with already-tracked runtime files are not modified or untracked automatically.
+
+## Findings
+
+[Populated by smaqit.task-complete. Do not fill in manually before task is complete.]
+
+**Implementation approach:**
+- TBD
+
+**Decisions made:**
+- TBD
+
+**Blockers encountered:**
+- TBD
+
+**Follow-up identified:**
+- TBD
+
+## Files to Create / Modify
+
+| File | Action |
+|------|--------|
+| `installer/` initialization/update implementation | Modify |
+| `installer/*_test.go` | Modify |
+| `scripts/smoke-test-installer.sh` | Modify |
+| Consumer installation documentation | Modify |
+
+## Notes
+
+v2.0.1 materializes approximately 3,875 files (about 67 MB) under `.smaqit/tools/plantuml/` for the pinned offline PlantUML toolchain. This is expected runtime content, but it should not appear as untracked consumer source files.

--- a/.smaqit/tasks/PLANNING.md
+++ b/.smaqit/tasks/PLANNING.md
@@ -4,7 +4,6 @@
 
 | ID | Title | Status | Priority |
 |----|-------|--------|----------|
-| 100 | Ignore Managed PlantUML Runtime Files | Not Started | High |
 | 094 | `smaqit.feature-new` — No Mandatory Browser/E2E Gate for Frontend-Touching Features | new | Medium |
 | 077 | Retroactive Specifications (for Brownfield Projects) | new | Medium |
 | 074 | Update "Extensible Through Templates" Principle Context | new | Low |
@@ -14,6 +13,7 @@
 
 | ID | Title |
 |----|-------|
+| 100 | Ignore Managed PlantUML Runtime Files |
 | 099 | Opaque PlantUML PNG Rendering |
 | 095 | `smaqit.feature-new` — Per-Phase `task.start`/`task.complete` Spawns Redundant Branches/Worktrees Instead of One Shared Feature Branch |
 | 098 | First-Class PlantUML Visual Design Artifacts |

--- a/.smaqit/tasks/PLANNING.md
+++ b/.smaqit/tasks/PLANNING.md
@@ -4,6 +4,7 @@
 
 | ID | Title | Status | Priority |
 |----|-------|--------|----------|
+| 100 | Ignore Managed PlantUML Runtime Files | Not Started | High |
 | 094 | `smaqit.feature-new` — No Mandatory Browser/E2E Gate for Frontend-Touching Features | new | Medium |
 | 077 | Retroactive Specifications (for Brownfield Projects) | new | Medium |
 | 074 | Update "Extensible Through Templates" Principle Context | new | Low |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Chore
 - Nothing to add.
 
+## [2.0.2] - 2026-08-06
+
+### Added
+- Nothing to add.
+
+### Changed
+- README and visual-design documentation now distinguish generated Git-ignored runtime tooling from versioned canonical design artifacts.
+
+### Deprecated
+- Nothing to add.
+
+### Removed
+- Nothing to add.
+
+### Fixed
+- Initialization and update now add the narrow `.smaqit/tools/` rule to the consumer root `.gitignore`, preserving existing rules and preventing the managed PlantUML runtime from appearing as thousands of untracked files.
+
+### Security
+- Nothing to add.
+
+### Chore
+- Nothing to add.
+
 ## [2.0.1] - 2026-08-06
 
 ### Added
@@ -689,7 +712,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Each layer's prompt file is sole source of requirements
   - Upstream layers provide context, not requirements
 
-[Unreleased]: https://github.com/ruifrvaz/smaqit/compare/v2.0.1...HEAD
+[Unreleased]: https://github.com/ruifrvaz/smaqit/compare/v2.0.2...HEAD
+[2.0.2]: https://github.com/ruifrvaz/smaqit/compare/v2.0.1...v2.0.2
 [2.0.1]: https://github.com/ruifrvaz/smaqit/compare/v2.0.0...v2.0.1
 [2.0.0]: https://github.com/ruifrvaz/smaqit/compare/v1.12.0...v2.0.0
 [1.12.0]: https://github.com/ruifrvaz/smaqit/compare/v1.11.0...v1.12.0

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Built for teams that value auditability, clear boundaries, and reproducible work
 
 ## Features
 
-- **One installer** — The released binary embeds smaqit's pinned PlantUML MCP, JavaScript/WASM renderer, font, templates, and agent integrations. Node.js 22+ is the only host prerequisite.
+- **One installer** — The released binary embeds smaqit's pinned PlantUML MCP, JavaScript/WASM renderer, font, templates, and agent integrations. Node.js 22+ is the only host prerequisite; the materialized local runtime under `.smaqit/tools/` is automatically Git-ignored.
 - **Visual design gates** — Minimal UML-style PlantUML/PNG design pairs are linked to every active specification, visually reviewed by specification agents, and automatically gated before implementation agents consume their PlantUML source.
 - **Traceable requirements** — Requirements captured in session context with full traceability from input to spec to implementation.
 - **Stateful specs** — Specifications track lifecycle: draft → implemented → deployed → validated.
@@ -98,6 +98,7 @@ Running `smaqit init` on an existing installation will:
 - **Preserve shared Codex configuration** — Unrelated `.codex/agents/`, `.agents/skills/`, and `.codex/config.toml` content is not changed
 - **Prompt for confirmation** — If smaqit files would be overwritten, you'll be asked to confirm
 - **Skip if no conflicts** — If only custom files exist, installation proceeds automatically
+- **Ignore managed runtime** — The installer adds the narrow `.smaqit/tools/` rule to your root `.gitignore`, preserving existing rules; canonical `docs/designs/` artifacts remain tracked
 
 This makes it safe to:
 - Upgrade to a new version of smaqit

--- a/docs/wiki/workflows/visual-designs.md
+++ b/docs/wiki/workflows/visual-designs.md
@@ -33,6 +33,6 @@ After updating and re-running `smaqit init`, an existing project with active spe
 
 ## Installation and Ownership
 
-The released Go binary embeds exact npm-lock-resolved dependencies for `@plantuml/mcp-js`, `@resvg/resvg-wasm`, and Noto Sans. Initialization first verifies the archive and Node.js 22+, then materializes the versioned runtime under `.smaqit/tools/plantuml/`. It configures the owned `smaqit-plantuml` server in `.vscode/mcp.json`, while Claude and Codex agents carry project-local MCP declarations.
+The released Go binary embeds exact npm-lock-resolved dependencies for `@plantuml/mcp-js`, `@resvg/resvg-wasm`, and Noto Sans. Initialization first verifies the archive and Node.js 22+, then materializes the versioned runtime under `.smaqit/tools/plantuml/`. It adds the narrow `.smaqit/tools/` rule to the project root `.gitignore`, preserving user rules so the generated runtime is not committed; canonical `docs/designs/` Markdown and PNG artifacts remain versioned. It configures the owned `smaqit-plantuml` server in `.vscode/mcp.json`, while Claude and Codex agents carry project-local MCP declarations.
 
 Reinstallation repairs smaqit-owned runtime/configuration and preserves unrelated MCP entries. Uninstall removes owned tooling and configuration but preserves `docs/designs/`.

--- a/installer/main.go
+++ b/installer/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"embed"
 	"fmt"
 	"io/fs"
@@ -405,6 +406,38 @@ func detectConflicts() []string {
 	return conflicts
 }
 
+const managedToolsGitignoreRule = ".smaqit/tools/"
+
+// ensureManagedToolsGitignore prevents the bundled, project-local PlantUML
+// runtime from becoming consumer source control content. It appends only the
+// exact managed rule, preserving all existing user-owned .gitignore content.
+func ensureManagedToolsGitignore(projectRoot string) error {
+	path := filepath.Join(projectRoot, ".gitignore")
+	content, err := os.ReadFile(path)
+	if err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	if err == nil {
+		for _, line := range strings.Split(string(content), "\n") {
+			if strings.TrimSpace(line) == managedToolsGitignoreRule {
+				return nil
+			}
+		}
+	}
+
+	newline := "\n"
+	if bytes.Contains(content, []byte("\r\n")) {
+		newline = "\r\n"
+	}
+	updated := append([]byte(nil), content...)
+	if len(updated) > 0 && !bytes.HasSuffix(updated, []byte("\n")) {
+		updated = append(updated, newline...)
+	}
+	updated = append(updated, managedToolsGitignoreRule...)
+	updated = append(updated, newline...)
+	return os.WriteFile(path, updated, 0o644)
+}
+
 func cmdInit(targetDir string) {
 	// The toolchain is mandatory. Fail before creating the target so an
 	// unsupported host never receives a partial smaqit installation.
@@ -510,6 +543,10 @@ func cmdInit(targetDir string) {
 	}
 	if _, err := materializeDesignTools("."); err != nil {
 		fmt.Printf("Error installing mandatory PlantUML runtime: %v\n", err)
+		os.Exit(1)
+	}
+	if err := ensureManagedToolsGitignore("."); err != nil {
+		fmt.Printf("Error updating .gitignore for managed PlantUML runtime: %v\n", err)
 		os.Exit(1)
 	}
 	if err := installVSCodeMCPConfig("."); err != nil {

--- a/installer/main_test.go
+++ b/installer/main_test.go
@@ -2,9 +2,63 @@ package main
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 )
+
+func TestEnsureManagedToolsGitignorePreservesExistingRules(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, ".gitignore")
+	const existing = "node_modules/\r\nuser-owned-rule/\r\n"
+	if err := os.WriteFile(path, []byte(existing), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := ensureManagedToolsGitignore(root); err != nil {
+		t.Fatal(err)
+	}
+	if err := ensureManagedToolsGitignore(root); err != nil {
+		t.Fatal(err)
+	}
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := existing + managedToolsGitignoreRule + "\r\n"
+	if string(content) != want {
+		t.Fatalf(".gitignore = %q, want %q", content, want)
+	}
+	if strings.Count(string(content), managedToolsGitignoreRule) != 1 {
+		t.Fatalf("managed rule was duplicated: %q", content)
+	}
+}
+
+func TestManagedToolsGitignoreDoesNotIgnoreDesignArtifacts(t *testing.T) {
+	root := t.TempDir()
+	if output, err := exec.Command("git", "init", "-q", root).CombinedOutput(); err != nil {
+		t.Fatalf("initialize test repository: %v: %s", err, output)
+	}
+	if err := ensureManagedToolsGitignore(root); err != nil {
+		t.Fatal(err)
+	}
+
+	isIgnored := func(path string) bool {
+		return exec.Command("git", "-C", root, "check-ignore", "-q", path).Run() == nil
+	}
+	if !isIgnored(".smaqit/tools/plantuml/runtime.js") {
+		t.Fatal("managed runtime path is not ignored")
+	}
+	for _, designPath := range []string{
+		"docs/designs/business/dsg-bus-login.md",
+		"docs/designs/business/dsg-bus-login.png",
+	} {
+		if isIgnored(designPath) {
+			t.Fatalf("canonical design artifact is ignored: %s", designPath)
+		}
+	}
+}
 
 func TestRemoveEmbeddedFilesPreservesUnownedCodexAgents(t *testing.T) {
 	dstDir := filepath.Join(t.TempDir(), ".codex", "agents")

--- a/scripts/smoke-test-installer.sh
+++ b/scripts/smoke-test-installer.sh
@@ -58,6 +58,8 @@ assert_owned_tree_matches() {
 echo "[INFO] Installer: $binary"
 echo "[INFO] Temporary project: $smoke_root"
 
+git init -q "$smoke_root"
+
 node_failure_target="$smoke_root/node-prerequisite-failure"
 if PATH=/smaqit-node-intentionally-unavailable "$binary" init "$node_failure_target" > "$smoke_root/node-failure.txt" 2>&1; then
   echo "[ERROR] Initialization succeeded without the mandatory Node prerequisite" >&2
@@ -77,6 +79,7 @@ printf '%s\n' 'custom_config = true' > "$smoke_root/.codex/config.toml"
 printf '%s\n' 'name = "custom-agent"' > "$smoke_root/.codex/agents/custom-agent.toml"
 printf '%s\n' '---' 'name: custom-skill' 'description: Unrelated sentinel skill.' '---' > "$smoke_root/.agents/skills/custom-skill/SKILL.md"
 printf '%s\n' 'custom neighbor inside a smaqit-named skill directory' > "$smoke_root/.agents/skills/smaqit.input-business/custom-note.txt"
+printf '%s\n' 'user-owned-rule/' > "$smoke_root/.gitignore"
 printf '%s\n' '{' '  // unrelated MCP configuration must survive' '  "servers": {"custom-server": {"command": "custom"}}' '}' > "$smoke_root/.vscode/mcp.json"
 printf '%s\n' 'user-owned-design-sentinel' > "$smoke_root/docs/designs/business/sentinel.txt"
 
@@ -105,6 +108,16 @@ assert_owned_tree_matches "$repo_root/installer/agents-codex" "$smoke_root/.code
 assert_owned_tree_matches "$repo_root/installer/skills-codex" "$smoke_root/.agents/skills" "Codex skills"
 test -f "$smoke_root/.smaqit/templates/designs/business.template.md"
 test -f "$smoke_root/.smaqit/tools/plantuml/plantuml-mcp-js-0.2.0_resvg-wasm-2.6.2_noto-sans-5.3.0_opaque-png-1/node_modules/@plantuml/mcp-js/server.js"
+grep -Fxq 'user-owned-rule/' "$smoke_root/.gitignore"
+test "$(grep -Fxc '.smaqit/tools/' "$smoke_root/.gitignore")" -eq 1
+git -C "$smoke_root" check-ignore -q .smaqit/tools/plantuml/plantuml-mcp-js-0.2.0_resvg-wasm-2.6.2_noto-sans-5.3.0_opaque-png-1/node_modules/@plantuml/mcp-js/server.js
+if git -C "$smoke_root" check-ignore -q docs/designs/business/sentinel.txt; then
+  echo "[ERROR] Canonical design artifacts must not be ignored" >&2
+  exit 1
+fi
+tracked_runtime="$smoke_root/.smaqit/tools/plantuml/plantuml-mcp-js-0.2.0_resvg-wasm-2.6.2_noto-sans-5.3.0_opaque-png-1/node_modules/@plantuml/mcp-js/server.js"
+git -C "$smoke_root" add -f "$tracked_runtime"
+git -C "$smoke_root" ls-files --error-unmatch "$tracked_runtime" >/dev/null
 for layer in business functional stack infrastructure coverage; do
   test -d "$smoke_root/docs/designs/$layer"
 done
@@ -291,6 +304,9 @@ grep -Fq 'cancel-sentinel' "$smoke_root/.codex/agents/$owned_agent_name"
 grep -Fq 'corrupt-runtime-sentinel' "$runtime_lock"
 printf 'y\n' | "$binary" init "$smoke_root"
 assert_file_equal "$owned_agent" "$smoke_root/.codex/agents/$owned_agent_name" "confirmed reinstall"
+grep -Fxq 'user-owned-rule/' "$smoke_root/.gitignore"
+test "$(grep -Fxc '.smaqit/tools/' "$smoke_root/.gitignore")" -eq 1
+git -C "$smoke_root" ls-files --error-unmatch "$tracked_runtime" >/dev/null
 (
   cd "$smoke_root"
   "$binary" validate

--- a/smaqit.code-workspace
+++ b/smaqit.code-workspace
@@ -3,6 +3,10 @@
     {
       "name": "main",
       "path": "."
+    },
+    {
+      "name": "release/v2.0.1",
+      "path": "../smaqit-wt-release-v2.0.1"
     }
   ],
   "settings": {

--- a/smaqit.code-workspace
+++ b/smaqit.code-workspace
@@ -3,10 +3,6 @@
     {
       "name": "main",
       "path": "."
-    },
-    {
-      "name": "release/v2.0.1",
-      "path": "../smaqit-wt-release-v2.0.1"
     }
   ],
   "settings": {


### PR DESCRIPTION
## Summary

- Prepare the v2.0.2 patch-release changelog.
- Prevent the managed PlantUML runtime from appearing as thousands of untracked consumer files.

## Validation

- `make -C installer test`
- `make -C installer smoke-test`
- `make -C installer build-all`

## Post-Merge Automation

When this PR is merged to `main`, the post-merge workflow will automatically:

- Create and push git tag `v2.0.2`
- Build Linux, macOS, and Windows binaries (amd64/arm64)
- Publish the GitHub release with binaries and changelog

Workflow: `.github/workflows/post-merge-release.yml`