### PR TITLE
fix: show resolved project path during init

### DIFF
--- a/installer/main.go
+++ b/installer/main.go
@@ -525,6 +525,11 @@ func cmdInit(targetDir string) {
 		fmt.Printf("Error changing to directory %s: %v\n", targetDir, err)
 		os.Exit(1)
 	}
+	projectDir, err := os.Getwd()
+	if err != nil {
+		fmt.Printf("Error resolving project directory: %v\n", err)
+		os.Exit(1)
+	}
 
 	// Handle both reinstallation and an initial install that would overwrite an exact
 	// owned destination. Unrelated files in shared platform directories are not conflicts.
@@ -561,7 +566,7 @@ func cmdInit(targetDir string) {
 		fmt.Println()
 	}
 
-	fmt.Printf("Initializing smaqit project in %s...\n", targetDir)
+	fmt.Printf("Initializing smaqit project in %s...\n", projectDir)
 
 	// Create directory structure
 	dirs := []string{

--- a/scripts/smoke-test-installer.sh
+++ b/scripts/smoke-test-installer.sh
@@ -65,7 +65,8 @@ mkdir -p "$HOME/.agents/skills/custom-skill"
 printf '%s\n' 'user-owned content' > "$HOME/.agents/skills/custom-skill/SKILL.md"
 
 git init -q "$project"
-printf 'y\n' | "$binary" init "$project" >/dev/null
+init_output="$(cd "$project" && "$binary" init)"
+grep -Fq "Initializing smaqit project in $project..." <<< "$init_output"
 assert_file "$project/.smaqit/templates/specs/business.template.md" "project template"
 assert_file "$project/.smaqit/tools/plantuml/plantuml-mcp-js-0.2.0_resvg-wasm-2.6.2_noto-sans-5.3.0_opaque-png-1/node_modules/@plantuml/mcp-js/server.js" "project PlantUML runtime"
 for path in .github/agents .github/skills .claude .codex/agents .agents/skills; do


### PR DESCRIPTION
## Summary

- Resolve the project directory after `smaqit init` changes into its target.
- Show the absolute target path instead of the literal `.` for a no-argument invocation.
- Exercise the no-argument path in installer smoke coverage.

## Validation

- `make -C installer test`
- `make -C installer smoke-test`
- `bash -n scripts/smoke-test-installer.sh`
- `git diff --check`
