### PR TITLE
Prepare release v3.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Chore
 - Nothing to add.
 
+## [3.0.1] - 2026-08-11
+
+### Fixed
+- `smaqit init` now reports the resolved absolute project directory when invoked without a target argument, instead of the literal `.`.
+
 ## [3.0.0] - 2026-08-11
 
 ### Changed
@@ -762,7 +767,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Each layer's prompt file is sole source of requirements
   - Upstream layers provide context, not requirements
 
-[Unreleased]: https://github.com/ruifrvaz/smaqit/compare/v3.0.0...HEAD
+[Unreleased]: https://github.com/ruifrvaz/smaqit/compare/v3.0.1...HEAD
+[3.0.1]: https://github.com/ruifrvaz/smaqit/compare/v3.0.0...v3.0.1
 [3.0.0]: https://github.com/ruifrvaz/smaqit/compare/v2.4.0...v3.0.0
 [2.4.0]: https://github.com/ruifrvaz/smaqit/compare/v2.3.0...v2.4.0
 [2.3.0]: https://github.com/ruifrvaz/smaqit/compare/v2.2.0...v2.3.0

--- a/installer/main.go
+++ b/installer/main.go
@@ -51,7 +51,7 @@ var agentsMdTemplate embed.FS
 var claudeMdTemplate embed.FS
 
 // Version is set via ldflags during build: -X main.Version=$(VERSION)
-var Version = "3.0.0"
+var Version = "3.0.1"
 
 func main() {
 	if len(os.Args) < 2 {


### PR DESCRIPTION
## Summary

- Release the merged fix for `smaqit init` reporting `.` instead of its resolved project path.
- Sync the installer fallback version and changelog for v3.0.1.

## Validation

- `make -C installer test`
- `make -C installer smoke-test`
- `git diff --check`

## Post-Merge Automation

When this PR is merged to `main`, the post-merge workflow will automatically:

✅ Create git tag `v3.0.1`
✅ Publish GitHub Release with the changelog excerpt
✅ Build and upload the release binaries

Workflow: `.github/workflows/post-merge-release.yml`
